### PR TITLE
chore: Add @heroku/frontend-dev-tooling to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @heroku/front-end
+* @heroku/front-end @heroku/frontend-dev-tooling
 #ECCN:Open Source

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,9 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @heroku/front-end @heroku/frontend-dev-tooling
+# Comment line immediately above ownership line is reserved for related GUS information.
+# Please exercise caution while editing.
+
+#GUSINFO: Heroku FE Dev Tools,Heroku CLI & Plugins
+* @heroku/frontend-dev-tooling @heroku/front-end
 #ECCN:Open Source


### PR DESCRIPTION
## Summary

Add `@heroku/frontend-dev-tooling` team to CODEOWNERS file to ensure proper code review coverage.

## Changes

- Added `@heroku/frontend-dev-tooling` as a code owner alongside existing teams

## Context

This aligns the CODEOWNERS with the `team:developer-tooling` custom property and ensures the Developer Tooling team is notified for PR reviews.

---
*Automated update as part of team repository reconciliation.*