### PR TITLE
chore: Remove @heroku/front-end from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,5 @@
 # Please exercise caution while editing.
 
 #GUSINFO: Heroku FE Dev Tools,Heroku CLI & Plugins
-* @heroku/frontend-dev-tooling @heroku/front-end
+* @heroku/frontend-dev-tooling
 #ECCN:Open Source


### PR DESCRIPTION
## Summary

Remove `@heroku/front-end` team from CODEOWNERS file.

## Context

This aligns the CODEOWNERS with the `team:developer-tooling` custom property.